### PR TITLE
Clean up tests

### DIFF
--- a/metagraph_igraph/tests/conftest.py
+++ b/metagraph_igraph/tests/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-from metagraph.core.resolver import Resolver
-
-
-@pytest.fixture(scope="session")
-def default_plugin_resolver():
-    res = Resolver()
-    res.load_plugins_from_environment()
-    return res

--- a/metagraph_igraph/tests/test_translators.py
+++ b/metagraph_igraph/tests/test_translators.py
@@ -2,6 +2,7 @@ import pytest
 import metagraph as mg
 from metagraph import IndexedNodes
 from metagraph.plugins import has_grblas
+from metagraph.tests.util import default_plugin_resolver
 import igraph
 from ..types import IGraph
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+# Run metagraph tests to exercise algorithms
+pytest --pyargs metagraph
+# Run local tests
+pytest


### PR DESCRIPTION
- Remove conftest and default_plugin_resolver fixture
- Use default_plugin_resolver from metagraph
- Add "run_tests.sh" script to run both metagraph and metagraph-igraph tests